### PR TITLE
Instructions on building

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,24 @@ arguments parsing and usage):
   respectively) which sum the list of numbers (nats and ints respectively) they are
   given.
 
-## Dependencies
+## Building
 
 This work has been tested using:
 
 * Agda version 2.5.3
 * The [standard library](http://github.com/agda/agda-stdlib) version 0.15
+
+To build everything:
+
+```bash
+git clone --branch v0.15 http://github.com/agda/agda-stdlib
+./agdARGS/all.sh && mv All.agda agdARGS
+AGDA_STDLIB=$PWD/agda-stdlib
+agda -i . \
+     -i $AGDA_STDLIB \
+     -c --compile-dir=__build \
+     ./agdARGS/All.agda
+```
+
+If you already have a copy of the standard library, you can just set
+`AGDA_STDLIB` appropriately.

--- a/agdARGS/all.sh
+++ b/agdARGS/all.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-echo "module agdARGS.All where\n" > All.agda
+echo "module agdARGS.All where" > All.agda
 git ls-tree --full-tree -r --name-only HEAD | grep "\.agda$" | sed "s/\.agda$//" | sed "s|^|open import |" | sed "s|/|.|g" | sort >> All.agda

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
-agda-2.5.3 -i . -i ~/languages/agda/libs/agda-stdlib/src/ -i ~/projects/potpourri/agda/ $1 -c --compile-dir=__build
+agda -i . \
+     -i $AGDA_STDLIB \
+     -c --compile-dir=__build \
+     "$1"


### PR DESCRIPTION
This should make it clearer for newcomers!

There's only one problem: it doesn't currently work.  Building with these instructions yields
```
 Loading  agdARGS.Examples.WordCount (/home/siddharthist/code/agda-scheme/agdARGS/agdARGS/Examples/WordCount.agdai).
 Checking agdARGS.System.Console.Options (/home/siddharthist/code/agda-scheme/agdARGS/agdARGS/System/Console/Options.agda).
/home/siddharthist/code/agda-scheme/agdARGS/agdARGS/System/Console/Options.agda:80,15-26
Failed to find source of module lib.Nullary in any of the following
locations:
  /home/siddharthist/code/agda-scheme/agda-stdlib/src/lib/Nullary.agda
  /home/siddharthist/code/agda-scheme/agda-stdlib/src/lib/Nullary.lagda
  /home/siddharthist/code/agda-scheme/agdARGS/lib/Nullary.agda
  /home/siddharthist/code/agda-scheme/agdARGS/lib/Nullary.lagda
  /home/siddharthist/code/agda-scheme/agdARGS/agda-stdlib/lib/Nullary.agda
  /home/siddharthist/code/agda-scheme/agdARGS/agda-stdlib/lib/Nullary.lagda
  /home/siddharthist/code/agda-scheme/agdARGS/lib/Nullary.agda
  /home/siddharthist/code/agda-scheme/agdARGS/lib/Nullary.lagda
  /nix/store/hiyy7rnjbsvgm66ciabqlwy62i6v6bzm-Agda-2.5.3-data/share/ghc-8.2.2/x86_64-linux-ghc-8.2.2/Agda-2.5.3/lib/prim/lib/Nullary.agda
  /nix/store/hiyy7rnjbsvgm66ciabqlwy62i6v6bzm-Agda-2.5.3-data/share/ghc-8.2.2/x86_64-linux-ghc-8.2.2/Agda-2.5.3/lib/prim/lib/Nullary.lagda
when scope checking the declaration
  open import lib.Nullary
```
Where is the `lib` library supposed to be located? Should this module be importing from `Relation.Nullary` in the standard library?